### PR TITLE
Update github action to run on main branch

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo content
-        uses: actions/checkout@v3
+        uses: nschloe/action-checkout-with-lfs-cache@v1
 
       - name: setup python
         uses: actions/setup-python@v4


### PR DESCRIPTION
closes #7 

Github action was updated to run on pull requests and commits to the main branch. It also had to be updated to properly use git-lfs.